### PR TITLE
Use dotenv for app as well as build

### DIFF
--- a/modules/utils/setEnv.js
+++ b/modules/utils/setEnv.js
@@ -1,4 +1,5 @@
 const argv = require('minimist')(process.argv.slice(2));
+require('dotenv').config();
 
 const { _, ...flags } = argv;
 
@@ -7,8 +8,7 @@ Object.keys(flags || {}).map(key => {
   process.env[key] = value;
 });
 
-process.env.ENABLE_CLOUDFLARE =
-  flags.ENABLE_CLOUDFLARE === 'true' ? true : false;
+process.env.ENABLE_CLOUDFLARE = !!process.env.ENABLE_CLOUDFLARE;
 
 export default function() {
   return _;


### PR DESCRIPTION
Included dotenv in app as it allows easier setup of environments without having to remember runtime arguments. If both are present the arguments will overwrite the .env variables. 

Bonus: Keeps secrets out of the shell history.